### PR TITLE
perf: 选择器卡片输入内容自适应显示

### DIFF
--- a/src/views/snapshot/SearchCard.vue
+++ b/src/views/snapshot/SearchCard.vue
@@ -245,6 +245,8 @@ const shareResult = (result: SearchResult) => {
           v-model:value="searchText"
           :placeholder="enableSearchBySelector ? `请输入选择器` : `请输入字符`"
           :inputProps="{ class: 'gkd_code' }"
+          type="textarea"
+          :autosize="{ minRows: 1, maxRows: 10 }"
           @keyup.enter="searchBySelector"
         />
         <NButton @click="searchBySelector">


### PR DESCRIPTION
issues: #56 
### 我自己找的教程改的，用html `textarea`来支持多行文本显示，滚动条显示的话初始为一行，到第十行不扩大容器使用它
<img width="913" height="453" alt="图片" src="https://github.com/user-attachments/assets/8773c8ae-8eed-42ed-9c2b-e68cb7d87dfb" />
