### PR TITLE
feat: 支持快照截图为WebP格式的快照导入导出

### DIFF
--- a/src/utils/export.ts
+++ b/src/utils/export.ts
@@ -30,9 +30,8 @@ export const exportSnapshotAsZip = async (snapshot: Snapshot) => {
 export const exportSnapshotAsImage = async (snapshot: Snapshot) => {
   const fileName = `snapshot-${snapshot.id}.png`;
   saveAs(
-    new Blob([(await screenshotStorage.getItem(snapshot.id))!], {
-      type: 'image/png',
-    }),
+    // 移除固定 image/png MIME，浏览器自动识别二进制格式
+    new Blob([(await screenshotStorage.getItem(snapshot.id))!]),
     fileName,
   );
 };
@@ -43,9 +42,7 @@ export const batchImageDownloadZip = async (snapshots: Snapshot[]) => {
     await delay();
     zip.file(
       snapshot.id + `.png`,
-      new Blob([(await screenshotStorage.getItem(snapshot.id))!], {
-        type: 'image/png',
-      }),
+      new Blob([(await screenshotStorage.getItem(snapshot.id))!]),
     );
   }
   const batchZipFile = await zip.generateAsync({
@@ -70,7 +67,8 @@ export const batchZipDownloadZip = async (snapshots: Snapshot[]) => {
 
 const comporessPngToJpg = async (imgBf: ArrayBuffer): Promise<Blob> => {
   return new Promise<Blob>((res, rej) => {
-    new Compressor(new Blob([imgBf], { type: 'image/png' }), {
+    // 移除写死的 image/png
+    new Compressor(new Blob([imgBf]), {
       quality: 0.75,
       convertSize: 200_000,
       success(file) {

--- a/src/utils/import.ts
+++ b/src/utils/import.ts
@@ -10,7 +10,9 @@ import type { JSZipType } from './chunk';
 
 const parseZip = async (zip: JSZipType) => {
   const snapshotFile = zip.filter((s) => s.endsWith(`.json`))[0];
-  const screenshotFile = zip.filter((s) => s.endsWith(`.png`))[0];
+  const screenshotFile = zip.filter(
+    (s) => s.endsWith(`.png`) || s.endsWith(`.webp`),
+  )[0];
   if (!snapshotFile || !screenshotFile) {
     return false;
   }
@@ -105,7 +107,9 @@ export const importFromNetwork = async (
         if (isZipBf(bf)) {
           const zip = await loadAsync(bf);
           const [snapshotFile] = zip.filter((p) => p.endsWith(`.json`));
-          const [screenshotFile] = zip.filter((p) => p.endsWith(`.png`));
+          const [screenshotFile] = zip.filter(
+            (p) => p.endsWith(`.png`) || p.endsWith(`.webp`),
+          );
           if (!snapshotFile || !screenshotFile) {
             return;
           }

--- a/src/views/snapshot/snapshot.ts
+++ b/src/views/snapshot/snapshot.ts
@@ -73,11 +73,7 @@ export const useSnapshotStore = createSharedComposable(() => {
   const screenshot = shallowRef<ArrayBuffer>();
   const screenshotUrl = computed(() => {
     if (screenshot.value) {
-      return URL.createObjectURL(
-        new Blob([screenshot.value], {
-          type: 'image/png',
-        }),
-      );
+      return URL.createObjectURL(new Blob([screenshot.value]));
     }
     return undefined;
   });


### PR DESCRIPTION
1. import.ts: 解析 zip 时同时匹配 png/webp 截图文件
2. snapshot.ts: 移除截图 Blob 固定 image/png 类型，兼容 WebP
3. export.ts: 移除所有图片导出硬编码 MIME, 自适应图片二进制格式

完全兼容原有 PNG 快照，无破坏性改动
导出的截图文件名后缀仍是.png，但二进制是标准 WebP，本地看图软件、浏览器都能正常打开，不会损坏图片

关联 https://github.com/gkd-kit/gkd/pull/1412